### PR TITLE
Added ability to handle mutliple organisms + different germplasm types

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@ This module provides a drush command to load genotypic data from a variety of fi
  - Alias: load-geno
  - Arguments:
    - input-file: The filename of the matrix file for upload
-   - sample-file: The filename of a tab-delimited file specifying for each sample name in the genotypes file: the name of the stock in the database, the stock accession ID, the name of the germplasm, and the germplasm Accession ID. See "samples.list" in the sample_files folder.
+   - sample-file: The filename of a tab-delimited file specifying for each sample name in the genotypes file: the name of the stock in the database, the stock accession ID, the name of the germplasm, the germplasm Accession ID, type fo germplasm, and organism (optional). See "samples.list" in the sample_files folder for an example.
  - Options:
    - variant-type: The Sequence Ontology (SO) term name that describes the type of variants in the file (eg. SNP, MNP, indel).
    - marker-type: A free-text title that describes the marker technology used to generate the genotypes in the file (e.g. "Exome Capture", "GBS", "KASPar", etc.).
    - ndgeolocation: A meaningful location associated with this natural diversity experiment. For example, this could be the location the assay was completed in, the location the germplasm collection was from, or the location the markers were developed at. This should be the description field of your ndgeolocation.
-   - organism: The organism to which the genotypes are associated with.
+   - organism: The organism of the reference genome which was used for aligning reads to call the variants. If there is an empty value in the "Organism" column of the sample file, the loader will default to this parameter.
    - project-name: All genotypes will be grouped via a project to allow users to specify a particular dataset.
 
 **This loader supports 3 different file formats (described under file formats below) and will auto-detect which format you have provided.**
@@ -26,7 +26,7 @@ Example Usage:
 ## File Formats
 This module supports loading of three types of genotype files:
  - VCF
- 
+
  ```
 ##fileformat=VCFv4.0
 ##fileDate=20090805
@@ -53,7 +53,7 @@ This module supports loading of three types of genotype files:
 1A	11111	1subfield	C	A	50	PASS	A=1;B=2;C=3	GT	0/1	./.	1/1
 ```
  - Genotype Matrix: a tab-delimited data file where each line corresponds to a SNP and columns correspond to germplasm assayed. Expected columns: (1) Marker Name, (2) Chromosome Name, (3) Position on Chromosome, (4+) Sample Genotype Calls.
- 
+
  ```
  Marker name	Chromosome	Position	1048-8R	964a-46	Giftgi
 FcChr1Ap11111	1A	11111	CC	AC	AA
@@ -61,7 +61,7 @@ FcChr1Ap22222	1A	22222	GG	GC	GG
 FcChr1Ap33333	1A	33333	TA	AA	GA
 ```
  - Genotype Flat-file: a tab delimited data file where each line is a genotypic call. Expected columns: (1) Marker name, (2)	Chromosome Name, (3)	Position on Chromosome, (4)	Sample Name, (5) Genotype call.
- 
+
  ```
 Marker name	Chromosome	Position	Sample name	Genotype call
 FcChr1Ap11111	1A	11111	Ross	CC
@@ -76,7 +76,7 @@ FcChr1Ap11111	1A	11111	Zapelli	CC
 FcChr1Ap11111	1A	11111	Amato	CG
 ```
 
-All formats require a separate samples file describing the germplasm assayed. This file is expected to be a tab-delimited file with the following columns: (1) Sample Name in File, (2)	Sample name,	(3) Sample Accession,	(4) Germplasm name, (5)	Germplasm Accession. 
+All formats require a separate samples file describing the germplasm assayed. This file is expected to be a tab-delimited file with the following columns: (1) Sample Name in File, (2)	Sample name,	(3) Sample Accession,	(4) Germplasm name, (5)	Germplasm Accession.
 
 ```
 Sample_name	Sample_name	Sample_Accession	Germplasm_name	Germplasm_Accession

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Example Usage:
    - `drush load-genotypes mygenotypes.vcf samples.list --organism="Lens culinaris" --variant-type="SNP" --marker-type="genetic_marker" --project-name="My SNP Discovery Project" --ndgeolocation="here"`
 
 ## File Formats
+### Genotypes File
 This module supports loading of three types of genotype files:
  - VCF
 
@@ -56,7 +57,7 @@ This module supports loading of three types of genotype files:
 1A	1230237	.	T	.	47	PASS	NS=3;DP=13;AA=T	GT:GQ:DP:HQ	0|0:54:7:56,60	0|0:48:4:51,51	0/0:61:2
 1A	11111	1subfield	C	A	50	PASS	A=1;B=2;C=3	GT	0/1	./.	1/1
 ```
- - Genotype Matrix: a tab-delimited data file where each line corresponds to a SNP and columns correspond to germplasm assayed. Expected columns: (1) Marker Name, (2) Chromosome Name, (3) Position on Chromosome, (4+) Sample Genotype Calls.
+ - Genotype Matrix: a tab-delimited data file where each line corresponds to a SNP and columns correspond to germplasm assayed. Expected columns: **(1) Marker Name**, **(2) Chromosome Name**, **(3) Position on Chromosome**, **(4+) Sample Genotype Calls**.
 
  ```
  Marker name	Chromosome	Position	1048-8R	964a-46	Giftgi
@@ -64,7 +65,7 @@ FcChr1Ap11111	1A	11111	CC	AC	AA
 FcChr1Ap22222	1A	22222	GG	GC	GG
 FcChr1Ap33333	1A	33333	TA	AA	GA
 ```
- - Genotype Flat-file: a tab delimited data file where each line is a genotypic call. Expected columns: (1) Marker name, (2)	Chromosome Name, (3)	Position on Chromosome, (4)	Sample Name, (5) Genotype call.
+ - Genotype Flat-file: a tab delimited data file where each line is a genotypic call. Expected columns: **(1) Marker name**, **(2)	Chromosome Name**, **(3)	Position on Chromosome**, **(4)	Sample Name**, **(5) Genotype call**.
 
  ```
 Marker name	Chromosome	Position	Sample name	Genotype call
@@ -80,7 +81,10 @@ FcChr1Ap11111	1A	11111	Zapelli	CC
 FcChr1Ap11111	1A	11111	Amato	CG
 ```
 
-All formats require a separate samples file describing the germplasm assayed. This file is expected to be a tab-delimited file with the following columns: (1) Sample Name in File, (2)	Sample name,	(3) Sample Accession,	(4) Germplasm name, (5)	Germplasm Accession.
+### Samples File
+All formats require a separate samples file describing the germplasm assayed. This file is expected to be a tab-delimited file with the following columns: **(1) Sample name** in the genotypes file, **(2)	Sample name**,	**(3) Sample accession**,	**(4) Germplasm name**, **(5)	Germplasm accession**.
+
+The next two columns are optional: **(6) Germplasm type** (otherwise it is currently assumed to be of type 'Individual' from the stock_type cv) and **(7) Organism** (this allows multiple organisms in your genotypes file, assuming they have all been aligned to the same genome. Otherwise, the default value is the organism you specified as an option).
 
 ```
 Sample name	Sample_name	Sample_Accession	Germplasm_name	Germplasm_Accession	Germplasm_Type	Organism

--- a/README.md
+++ b/README.md
@@ -79,17 +79,17 @@ FcChr1Ap11111	1A	11111	Amato	CG
 All formats require a separate samples file describing the germplasm assayed. This file is expected to be a tab-delimited file with the following columns: (1) Sample Name in File, (2)	Sample name,	(3) Sample Accession,	(4) Germplasm name, (5)	Germplasm Accession.
 
 ```
-Sample_name	Sample_name	Sample_Accession	Germplasm_name	Germplasm_Accession
-Ross	Ross_110201	Catsam1	Ross	Catgerm1
-Prado	Prado_110201	Catsam2	Prado	Catgerm2
-Ash	Ash_110201	Catsam3	Ash	Catgerm3
-Piero	Piero_110201	Catsam4	Piero	Catgerm4
-Tai	Tai_110201	Catsam5	Tai	Catgerm5
-Beverly	Beverly_110201	Catsam6	Beverly	Catgerm6
-Argent	Argent_110201	Catsam7	Argent	Catgerm7
-Trenus	Trenus_110201	Catsam8	Trenus	Catgerm8
-Zapelli	Zapelli_110201	Catsam9	Zapelli	Catgerm9
-Amato	Amato_110201	Catsam10	Amato	Catgerm10
+Sample name	Sample_name	Sample_Accession	Germplasm_name	Germplasm_Accession	Germplasm_Type	Organism
+Ross	Ross_110201	Catsam1	Ross	Catgerm1	Individual	Felis catus
+Prado	Prado_110201	Catsam2	Prado	Catgerm2	Individual	Felis catus
+Ash	Ash_110201	Catsam3	Ash	Catgerm3	Individual	Felis catus
+Piero	Piero_110201	Catsam4	Piero	Catgerm4	Individual	Felis catus
+Tai	Tai_110201	Catsam5	Tai	Catgerm5	Individual	Felis catus
+Beverly	Beverly_110201	Catsam6	Beverly	Catgerm6	Individual	Felis catus
+Argent	Argent_110201	Catsam7	Argent	Catgerm7	Individual	Felis catus
+Trenus	Trenus_110201	Catsam8	Trenus	Catgerm8	Individual	Felis catus
+Zapelli	Zapelli_110201	Catsam9	Zapelli	Catgerm9	Individual	Felis catus
+Amato Amato_110201 Catsam10 Amato Catgerm10 Individual Felis catus
 ```
 
 ## Data Storage

--- a/genotypes_loader.drush.inc
+++ b/genotypes_loader.drush.inc
@@ -219,6 +219,8 @@ function genotypes_loader_load_genotypes($input_file = NULL, $sample_file = NULL
   }
 
   // ----- ORGANISM NAME -----
+  // This is the organism for which the chromosome/variants/markers are located on its genome, since multiple organisms 
+  // may be present in the input file but only one organism's genome would have had the sequence aligned to it.
   $organism_name = chado_query(
      "SELECT organism.genus||' '||organism.species
         FROM {organism}
@@ -273,6 +275,11 @@ function genotypes_loader_load_genotypes($input_file = NULL, $sample_file = NULL
     $sample_accession = array_shift($current_line);
     $germplasm_name = array_shift($current_line);
     $germplasm_accession = array_shift($current_line);
+    
+    // Setting the following as defaults if the 6th and/or 7th columns are not provided
+    $germplasm_type = 'Individual';
+    $organism_id = $options['organism_id'];
+    
     // User can optionally supply a stock_type for each germplasm if they are inserting
     if ($num_columns >= 6) {
       $germplasm_type = array_shift($current_line);
@@ -280,7 +287,6 @@ function genotypes_loader_load_genotypes($input_file = NULL, $sample_file = NULL
       if (!$types[$germplasm_type]) {
         // Query to retrieve type IDs was set above:
         // SELECT cvterm_id FROM {cvterm} WHERE name=:name AND cvterm.cv_id IN (SELECT cv_id FROM {cv} WHERE name=:cv_name)
-
         $cv_name = 'stock_type';
         $types[$germplasm_type] = chado_query($type_query, array(':name' => $germplasm_type, ':cv_name' => $cv_name))->fetchField();
       }
@@ -288,6 +294,7 @@ function genotypes_loader_load_genotypes($input_file = NULL, $sample_file = NULL
         return drush_set_error(dt("ERROR: Could not find germplasm type '@type' with the vocabulary '@cv_name'.", array('@type' => $germplasm_type, '@cv_name' => $cv_name,)));
       }
     }
+    
     // User can optionally supply an organism for each germplasm if they are inserting germplasm into the database.
     // We need to allow spaces in the genus and species, so use a custom query to check that what the user
     // input matches what is in the database.
@@ -314,11 +321,11 @@ function genotypes_loader_load_genotypes($input_file = NULL, $sample_file = NULL
     // ----- STOCK -----
     $stock_id = genotypes_loader_helper_add_record_with_mode('Sample', 'stock', $options['insert_samples'], array(
       'uniquename' => $sample_accession,
-      // @ASSUMPTION: The original stock for which the marker is associated to is of type genomic_DNA
+      'organism_id' => $organism_id,
+      // @ASSUMPTION: The original stock for which the marker is associated to is of type 'genomic_DNA'.
       'type_id' => $types['genomic_DNA'],
     ), array(
       'name' => $sample_name,
-      'organism_id' => $options['organism_id'],
     ));
     if (!$stock_id) { return drush_set_error(dt('ERROR: Could not find a stock ID for @stock', array('@stock' => $sample_accession))); }
 //    drush_print("Found stock ID: $stock_id for sample: $sample_name");
@@ -326,13 +333,16 @@ function genotypes_loader_load_genotypes($input_file = NULL, $sample_file = NULL
     // ----- GERMPLASM -----
     $germplasm_id = genotypes_loader_helper_add_record_with_mode('Germplasm', 'stock', $options['insert_germplasm'], array(
       'uniquename' => $germplasm_accession,
-    ), array(
       // @ASSUMPTION: If a germplasm already exists, we don't assume its type, but we do require
-      //              a type if we're inserting. So here we are assuming it is of type "Individual".
+      //              a type if we're inserting. So unless it was specified in the samples list, we 
+      //              are assuming type 'Individual'. Ideally, this user could provide the default type
+      //              as an option like with organism. *wink wink nudge nudge*
       'type_id' => $types[$germplasm_type],
+      'organism_id' => $organism_id,
+    ), array(
       'name' => $germplasm_name,
-      'organism_id' => $options['organism_id'],
     ));
+    
     if (!$germplasm_id) { return drush_set_error(dt('ERROR: Could not find a germplasm ID for @germplasm', array('@germplasm' => $germplasm_accession))); }
 //    drush_print("Found stock ID: $germplasm_id for germplasm: $germplasm_name");
 

--- a/sample_files/cats.list
+++ b/sample_files/cats.list
@@ -9,3 +9,5 @@ Argent	Argent_110201	Catsam7	Argent	Catgerm7	Individual	Felis catus
 Trenus	Trenus_110201	Catsam8	Trenus	Catgerm8	Individual	Felis catus
 Zapelli	Zapelli_110201	Catsam9	Zapelli	Catgerm9	Individual	Felis catus
 Amato	Amato_110201	Catsam10	Amato	Catgerm10	Individual	Felis catus
+Fireball	Fireball_140619	Catsam11	Fireball	Catgerm11	Individual	Felis silvestris
+StabbyStab	StabbyStab_140619	Catsam12	StabbyStab	Catgerm12	Individual	Felis silvestris

--- a/sample_files/cats.vcf
+++ b/sample_files/cats.vcf
@@ -1,4 +1,4 @@
 ##fileformat=VCFv4.0
-#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	Ross	Prado	Ash	Piero	Tai	Beverly	Argent	Trenus	Zapelli	Amato
-1A	11111	.	A	G	29	PASS	.	GT:DP	0/0:10	0/0:9	0/0:8	0/1:9	./.	1/1:5	0/1:11	0/0:3	1/1:6	0/0:4
-1A	22222	.	T	C	36	PASS	.	GT:DP	1/1:5	0/0:7	0/0:15	./.	0/0:8	0/1:5	0/0:1	0/1:13	0/0:6	1/1:4
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	Ross	Prado	Ash	Piero	Tai	Beverly	Argent	Trenus	Zapelli	Amato	Fireball	StabbyStab
+1A	11111	.	A	G,C	29	PASS	.	GT:DP	0/0:10	0/0:9	0/0:8	0/1:9	./.	1/1:5	0/1:11	0/0:3	1/1:6	0/0:4	2/2:5	2/2:8
+1A	22222	.	T	C,A	36	PASS	.	GT:DP	1/1:5	0/0:7	0/0:15	./.	0/0:8	0/1:5	0/0:1	0/1:13	0/0:6	1/1:4	2/2:8	0/2:6


### PR DESCRIPTION
Addresses Issue #2 

Implementation began last year was and was committed to the master branch, so this pull request is meant to finalize the functionality (and follow best practices 👍). Additions were:
- Add an extra organism to the sample files for demonstration and testing
- Update the README
- Set defaults for both germplasm type and organism in case they aren't provided. When selecting pre-existing stocks and germplasm, the module now requires the organism and type in addition to the unique name. This is to ensure that a unique stock/germplasm is ALWAYS selected, in case a name is shared among different organisms.
- Fixed a bug (or just forgot to implement?) where organism was always being pulled from the option set by the user rather than the samples file.

Commands for testing:
- On a fresh Tripal site:
  - `drush sql-query "INSERT INTO chado.organism (genus, species, common_name, comment) VALUES ('Felis', 'catus', 'Cat', 'The domestic cat is a small, typically furry, carnivorous mammal. They are often called house cats when kept as indoor pets or simply cats when there is no need to distinguish them from other felids and felines. They are often valued by humans for companionship and for their ability to hunt vermin.')"`
  - `drush sql-query "INSERT INTO chado.organism (genus, species, common_name, comment) VALUES ('Felis', 'silvestris', 'Wild Cat', 'Wild cats are found throughout continental Europe, southwestern Asia, and the savannah regions of Africa. Felis silvestris is currently regarded as being made up of three, distinct groups (or subspecies): F. silvestris lybica, African wild cats, F. silvestris silvestris, European wild cats, and F. silvestris ornata, Asiatic wild cats.')"`
  - `drush sql-query "INSERT INTO chado.project (name, description) VALUES ('My SNP Discovery Project', 'I discovered some SNPs in cats.')"`
  - `drush php-eval "tripal_insert_cvterm(array(
            'id' => 'stock_type' . ':' . 'Individual',
            'name' => 'Individual',
            'cv_name' => 'stock_type',
          ));"`
  - `drush php-eval "chado_insert_record('feature', array(
        'name' => '1A',
        'uniquename' => '1A',
        'organism_id' => array(
          'genus' => 'Felis',
          'species' => 'catus',
        ),
        'type_id' => array(
          'cv_id' => array(
            'name' => 'sequence',
          ),
          'name' => 'chromosome',
          'is_obsolete' => 0
        )));"`
  - `drush load-genotypes sample_files/cats.vcf sample_files/cats.list --marker-type="genetic_marker" --variant-type="SNP" --organism="Felis catus" --project-name="My SNP Discovery Project" --ndgeolocation="here"`
- On a KP clone:
  - `drush load-genotypes sample_files/sample.vcf sample_files/samples.list --marker-type="genetic_marker" --variant-type="SNP" --organism="Lens culinaris" --project-name="Issue2 Genotypes Loader Test" --ndgeolocation="here"`
  - The samples.list file would need a new organism added and genotypes for that organism added to sample.vcf (sample.flat.tsv or sample.matrix.small may also be used in place of sample.vcf)