### PR TITLE
Improvements to speed by inserting genotype calls via /COPY

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -4,6 +4,15 @@
 <!--- If it fixes an open issue, please add the issue link below. -->
 Issue #
 
+<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+- [ ] I feel this PR is ready to be merged.
+- [ ] My code follows the code style of this project.
+- [ ] My change requires a change to the documentation.
+- [ ] I have updated the documentation accordingly.
+- [ ] I tested on a generic Tripal Site
+- [ ] I tested on a KnowPulse Clone
+
 ## Description
 <!--- Describe your changes in detail -->
 <!--- Why is this change required? What problem does it solve? -->

--- a/api/genotypes_loader.api.inc
+++ b/api/genotypes_loader.api.inc
@@ -159,10 +159,20 @@ function genotypes_loader_helper_copy_records($record_count, $record_type, $tabl
   }
   
   if (($record_count%$copy_chunk_size == 0) || ($final_chunk)) {
-    // Determine the COPY Command using the keys of the values array (i.e. the fields)
-    // and the file name.
-    //$copy_command = 'COPY {' . $table . '} (' . implode(',', array_keys($values) . ") FROM '$file_name' WITH CSV";
+    // Determine the COPY Command using the table (though we are hard-coding the keys for security reasons) and the file name.
+    // Columns are listed in alphabetical order because we used ksort() before printing the values to a file.
+    $copy_command = "COPY chado.genotype_call (
+      genotype_id,
+      marker_id,
+      meta_data,
+      project_id,
+      stock_id,
+      variant_id)
+      FROM '$file_name' WITH CSV";
     //drush_print("The copy command: " . $copy_command);
+    genotypes_loader_remote_copy($copy_command);
+
+    drush_print("Copied in $record_count records.");
     
     // Wipe the file clean by reopening it as write-only
     $file_handle = fopen($file_name, 'w');

--- a/api/genotypes_loader.api.inc
+++ b/api/genotypes_loader.api.inc
@@ -159,7 +159,7 @@ function genotypes_loader_helper_copy_records($record_count, $record_type, $tabl
   }
   
   if (($record_count%$copy_chunk_size == 0) || ($final_chunk)) {
-    // Determine the COPY Command using the table (though we are hard-coding the keys for security reasons) and the file name.
+    // Write out the COPY command
     // Columns are listed in alphabetical order because we used ksort() before printing the values to a file.
     $copy_command = "COPY chado.genotype_call (
       genotype_id,
@@ -168,11 +168,9 @@ function genotypes_loader_helper_copy_records($record_count, $record_type, $tabl
       project_id,
       stock_id,
       variant_id)
-      FROM '$file_name' WITH CSV";
-    //drush_print("The copy command: " . $copy_command);
-    genotypes_loader_remote_copy($copy_command);
+      FROM STDIN WITH CSV";
 
-    drush_print("Copied in $record_count records.");
+    genotypes_loader_remote_copy($copy_command, $file_name);
     
     // Wipe the file clean by reopening it as write-only
     $file_handle = fopen($file_name, 'w');
@@ -197,16 +195,28 @@ function genotypes_loader_helper_copy_records($record_count, $record_type, $tabl
  *
  * @param $copy_command
  *   The full PostgreSQL copy command to be executed.
+ * @param $file_name
+ *   The name of the file from which COPY gets its contents to copy into the database
  */
-function genotypes_loader_remote_copy($copy_command) {
+function genotypes_loader_remote_copy($copy_command, $file_name) {
   
   // Execute the command within a drush created psql session using \COPY.
-  return drush_invoke_process(
+  $connection_string = `drush sql-connect`;
+  $connection_string = trim($connection_string);
+  $command = $connection_string . ' -c "\\' . $copy_command . '" < ' . $file_name;
+  
+  // Execute the command
+  //return `$command`;
+  drush_print("The copy command: " . $command);
+  
+  
+  /*return drush_invoke_process(
     '@self',
     'sql-cli',
     array(),
     array('extra' => '--command="\\'.$copy_command.'"')
   );
+  */
 }
 
 

--- a/api/genotypes_loader.api.inc
+++ b/api/genotypes_loader.api.inc
@@ -113,7 +113,7 @@ function genotypes_loader_helper_add_record_with_mode($record_type, $table, $mod
  * Places records into a CSV file, and then checks if it is time to bulk load the file via a COPY command
  * 
  * @param $record_count
- *   The current count (less than the copy_chunk_size) of records that are being loaded in.
+ *   The current count of records that are being loaded in.
  * @param $record_type
  *   A human-readable term for your record for error messages.
  * @param $table
@@ -122,11 +122,13 @@ function genotypes_loader_helper_add_record_with_mode($record_type, $table, $mod
  *   An array of [table column] => [value] mappings that is specific to the insert.
  * @param $file_name
  *   An optional name for the file to write the values to
+ * @param $final_chunk
+ *   If set to true, then the remaining genotypes have been added to the file and it is time to copy them in.
  * @return
  *   TRUE if success (meaning, we reached the end of the function, not neccesarily that everything went swimmingly), FALSE if failed.
  */
 
-function genotypes_loader_helper_copy_records($record_count, $record_type, $table, $insert_values = array(), $file_name = NULL) {
+function genotypes_loader_helper_copy_records($record_count, $record_type, $table, $insert_values = array(), $file_name = NULL, $final_chunk = FALSE) {
   
   // The number of records we want to reach before copying them in all at once
   $copy_chunk_size = 5;
@@ -140,26 +142,35 @@ function genotypes_loader_helper_copy_records($record_count, $record_type, $tabl
     $file_name = $file_stub . $table . '-' . $record_type . '.csv';
   }
   
-  // Now open the file to write to since this is needed by fputcsv.
+  // If this is the last chunk to be entered into the database, then we don't have a record to add to the file.
+  // Otherwise, open the file to write to since this is needed by fputcsv.
   // @TODO "Lacey: I'm concerned this might be a point of slowness. Perhaps there is a better
   //       way to create CSV that doesn't require fputcsv and is more reliable
   //       then simply imploding the values with comma's in-between."
-  $file_handle = fopen($file_name, 'a') or die ("ERROR: Unable to create $file_name to bulk load records!\n");;
-  ksort($insert_values); // to ensure they're always in the same order.
-  fputcsv($file_handle, $insert_values);
+  if (!$final_chunk) {
+    // If we don't have a record to load in, something has defintiely gone wrong
+    if ($record_count == 0) {
+      return drush_set_error(dt('There is no genotype call to print to @filename', array('@filename' => $file_name)));
+    }
+    $file_handle = fopen($file_name, 'a') or die ("ERROR: Unable to create $file_name to bulk load records!\n");;
+    ksort($insert_values); // to ensure they're always in the same order.
+    fputcsv($file_handle, $insert_values);
+    fclose($file_handle);
+  }
   
-  if ($record_count%$copy_chunk_size == 0) {
+  if (($record_count%$copy_chunk_size == 0) || ($final_chunk)) {
     // Determine the COPY Command using the keys of the values array (i.e. the fields)
     // and the file name.
     //$copy_command = 'COPY {' . $table . '} (' . implode(',', array_keys($values) . ") FROM '$file_name' WITH CSV";
     //drush_print("The copy command: " . $copy_command);
     
-    fclose($file_handle);
     drush_print("Yippee, copying in " . $record_count . " records now!");
     
     // Wipe the file clean by reopening it as write-only
     $file_handle = fopen($file_name, 'w');
-    //fclose($file_handle);
+    fclose($file_handle);
+    
+    drush_log("Copied in " . $record_count . " records.");
   }
   
   return TRUE;
@@ -332,7 +343,7 @@ function genotypes_loader_helper_add_genotypes_genotype_call($v, $num_calls = 0)
     'meta_data' => $v['meta_data'],
   );
   
-  $status = genotypes_loader_helper_copy_records('Genotype Call', 'genotype_call', $insert_values, $num_calls);
+  $status = genotypes_loader_helper_copy_records($num_calls, 'Genotype Call', 'genotype_call', $insert_values);
   
   
 //  $genotype_call_id = genotypes_loader_helper_add_record_with_mode('Genotype Call', 'genotype_call', $both, $select_values, $insert_values);

--- a/api/genotypes_loader.api.inc
+++ b/api/genotypes_loader.api.inc
@@ -151,7 +151,7 @@ function genotypes_loader_helper_copy_records($record_count, $record_type, $tabl
   if ($record_count%$copy_chunk_size == 0) {
     // Determine the COPY Command using the keys of the values array (i.e. the fields)
     // and the file name.
-    //$copy_command = 'COPY chado.' . $table . ' (' . implode(',', array_keys($values) . ") FROM '$file_name' WITH CSV";
+    //$copy_command = 'COPY {' . $table . '} (' . implode(',', array_keys($values) . ") FROM '$file_name' WITH CSV";
     //drush_print("The copy command: " . $copy_command);
     
     fclose($file_handle);
@@ -180,25 +180,7 @@ function genotypes_loader_helper_copy_records($record_count, $record_type, $tabl
  *   The full PostgreSQL copy command to be executed.
  */
 function genotypes_loader_remote_copy($copy_command) {
-  /**
-   * The following is the remote copy function used by the nd_genotypes module
-   * 
-  // Prefix the tables with their correct schema.
-  // Chado tables should be enclosed in curly brackets (ie: {feature} )
-  // and Drupal tables should be enclosed in square brackets (ie: [tripal_jobs] ).
-  $chado_schema_name = tripal_get_schema_name('chado');
-  $drupal_schema_name = tripal_get_schema_name('drupal');
-  $copy_command = preg_replace('/\{(.*?)\}/', $chado_schema_name.'.$1', $copy_command);
-  $copy_command = preg_replace('/\[(\w+)\]/', $drupal_schema_name.'.$1', $copy_command);
-  // Substitute any arguements for placeholders.
-  foreach ($args as $k => $v) {
-    if (is_string($v)) {
-      $args[$k] = "'" . $v . "'";
-    }
-  }
-  $copy_command = strtr($copy_command, $args);
-  // Allow the same hooks that act on chado_query to act on this query.
-  drupal_alter('chado_query', $copy_command, $args);
+  
   // Execute the command within a drush created psql session using \COPY.
   return drush_invoke_process(
     '@self',
@@ -206,8 +188,6 @@ function genotypes_loader_remote_copy($copy_command) {
     array(),
     array('extra' => '--command="\\'.$copy_command.'"')
   );
-  */
-  
 }
 
 

--- a/api/genotypes_loader.api.inc
+++ b/api/genotypes_loader.api.inc
@@ -32,6 +32,10 @@ function genotypes_loader_get_postgresql_version() {
  * Adds/Selects a record based on the mode. Helper function for loading genotype matrix
  * that does the select/insert based on mode logic.
  *
+ * @TODO: Give the different errors that are possible separate error codes. Also allow a parameter to be given to
+ * either "handle errors" or not- this way, if we see a certain error (such as not unique), we can handle it
+ * from outside of the function.
+ *
  * @param $record_type
  *   A human-readable term for your record for error messages.
  * @param $table
@@ -39,21 +43,14 @@ function genotypes_loader_get_postgresql_version() {
  * @param $mode
  *   One of 0: Select Only, 1: Insert Only, 2: Insert & Select.
  * @param $select_values
- *   An array of [table column] => [value] mappings. These will be used for both the
- *   select and the insert.
+ *   An array of [table column] => [value] mappings. These values will be used for both the
+ *   select and the insert, but are specific to select
  * @param $insert_values
- *   An array of [table column] => [value] mappings that is specific to the insert.
+ *   An array of [table column] => [value] mappings that is specific to the insert. This is not required if mode is
+ *   select only, and will be combined with select values for an insert.
  * @return
  *   The value of the primary key for the inserted/selected record or FALSE if failed.
  */
-
- /**
-  *  @TODO: Give the different errors that are possible separate error codes. Also allow a parameter to be given to
-  *  either "handle errors" or not- this way, if we see a certain error (such as not unique), we can handle it
-  *  from outside of the function.
-  *
-  */
-
 function genotypes_loader_helper_add_record_with_mode($record_type, $table, $mode, $select_values, $insert_values = array()) {
 
   // Set some variables to abstract mode
@@ -127,7 +124,6 @@ function genotypes_loader_helper_add_record_with_mode($record_type, $table, $mod
  * @return
  *   TRUE if success (meaning, we reached the end of the function, not neccesarily that everything went swimmingly), FALSE if failed.
  */
-
 function genotypes_loader_helper_copy_records($record_count, $record_type, $table, $insert_values = array(), $file_name = NULL, $final_chunk = FALSE) {
 
   // The number of records we want to reach before copying them in all at once
@@ -180,18 +176,16 @@ function genotypes_loader_helper_copy_records($record_count, $record_type, $tabl
   }
 
   return TRUE;
-
 }
 
 /**
  * Uses drush to safely copy data quickly. ONLY USE IN TRIPAL JOBS!!
  *
- * PostgreSQL COPY is extremely effective at copying/inserting large amount of
- * data. This modules uses it to create materialized views to cache queries
- * for faster data access. However, using chado_query('COPY...') poses many
- * security risks in a web setting. We use a combination of drush sql-cli,
- * which opens a psql session, and psql's \copy command to take advantage of
- * the fact that Tripal Jobs are run on the command-line.
+ * PostgreSQL COPY is extremely effective at copying/inserting large amounts of
+ * data. This modules uses it to make inserting massive genotype files more efficient.
+ * However, using chado_query('COPY...') poses many security risks in a web setting.
+ * Instead we use Drupal to determine the psql connection string, and psql's \copy command
+ * to take advantage of the fact that Tripal Jobs are run on the command-line.
  *
  * @param $copy_command
  *   The full PostgreSQL copy command to be executed.
@@ -209,9 +203,6 @@ function genotypes_loader_remote_copy($copy_command, $file_name) {
   return `$command`;
 
 }
-
-
-
 
 /**
  * Adds genotype records when using the ND Experiment Tables storage method. This is a
@@ -358,10 +349,6 @@ function genotypes_loader_helper_add_genotypes_genotype_call($v, $num_calls = 0,
 
   $status = genotypes_loader_helper_copy_records($num_calls, 'Genotype Call', 'genotype_call', $insert_values, $file_name);
 
-
-//  $genotype_call_id = genotypes_loader_helper_add_record_with_mode('Genotype Call', 'genotype_call', $both, $select_values, $insert_values);
-//  if (!$genotype_call_id) return FALSE;
-
   return TRUE;
 }
 
@@ -436,7 +423,6 @@ function genotypes_loader_helper_add_genotypes_stock_genotype($v) {
  *   An optional message that allows the user to print a message to the screen next to the
  *   progress bar at a particular step.
  */
-
 function genotypes_loader_print_progress($step_count, $num_steps, $message = "")
 {
     // Calculate percentage of steps completed
@@ -461,4 +447,3 @@ function genotypes_loader_print_progress($step_count, $num_steps, $message = "")
 
     return $output;
 }
-

--- a/api/genotypes_loader.api.inc
+++ b/api/genotypes_loader.api.inc
@@ -48,17 +48,24 @@ function genotypes_loader_get_postgresql_version() {
  */
 
  /**
-  *  Give the different errors that are possible separate error codes. Also allow a parameter to be given to
+  *  @TODO: Give the different errors that are possible separate error codes. Also allow a parameter to be given to
   *  either "handle errors" or not- this way, if we see a certain error (such as not unique), we can handle it
   *  from outside of the function.
   *
-  *  Also - don't forget to refer to Lacey's new helper function on Github. This function needs to evolve
-  *  regardless! Whether or not we go with copying from a file remains to be seen...
   */
 
 function genotypes_loader_helper_add_record_with_mode($record_type, $table, $mode, $select_values, $insert_values = array()) {
+  
+  // The number of records to copy at once
+  $copy_chunk_size = 50000;
+  
   // the name of the primary key.
   $pkey = $table . '_id';
+  
+  // If the mode is insert only, then we should be able to safely copy everything to a file and load in bulk
+  
+  // Else if the mode is insert & select, or select only, insert one record at a time
+  
   // First we select the record to see if it already exists.
   $record = chado_select_record($table, array($pkey), $select_values);
   // If we want to insert values, we can merge our values to have all the information we need

--- a/api/genotypes_loader.api.inc
+++ b/api/genotypes_loader.api.inc
@@ -43,8 +43,6 @@ function genotypes_loader_get_postgresql_version() {
  *   select and the insert.
  * @param $insert_values
  *   An array of [table column] => [value] mappings that is specific to the insert.
- * @param $file_name
- *   An optional name for the file to write the values to if mode is insert only
  * @return
  *   The value of the primary key for the inserted/selected record or FALSE if failed.
  */
@@ -56,12 +54,7 @@ function genotypes_loader_get_postgresql_version() {
   *
   */
 
-function genotypes_loader_helper_add_record_with_mode($record_type, $table, $mode, $select_values, $insert_values = array(), $file_name = NULL) {
-  
-  //drush_print("Record type: " . $record_type . ", Mode: " . $mode);
-  
-  // The number of records to copy at once
-  $copy_chunk_size = 50000;
+function genotypes_loader_helper_add_record_with_mode($record_type, $table, $mode, $select_values, $insert_values = array()) {
   
   // Set some variables to abstract mode
   $select_only = 0;
@@ -70,77 +63,101 @@ function genotypes_loader_helper_add_record_with_mode($record_type, $table, $mod
   
   // the name of the primary key.
   $pkey = $table . '_id';
+      
+  // First we select the record to see if it already exists.
+  $record = chado_select_record($table, array($pkey), $select_values); 
   
-  // If the mode is insert only, then we should be able to safely copy everything to a file and load in bulk
-  if ($mode == $insert_only) {
-    
-    // If we weren't given the name of the file to write to
-    // then we need to determine a file name in a repeatable but unique manner.
-    if ($file_name === NULL) {
-      $file_stub = '/tmp/genotype_loader.';
-      $record_type = str_replace(' ', '_', $record_type);
-      $record_type = strtolower($record_type);
-      $file_name = $file_stub . $table . '-' . $record_type . '.csv';
+  // If it exists and the mode is 1 (Insert Only) then return an error to drush.
+  if (sizeof($record) == 1) {
+    if ($mode == $insert_only) {
+      return drush_set_error(dt('Record "@record_type" already exists but you chose to only insert (mode=@mode). Values: ', array('@record_type' => $record_type, '@mode' => $mode)).print_r($select_values,TRUE));
     }
-    
-    //drush_print("Filename: " . $file_name);
-    
-    // Now open the file to write to since this is needed by fputcsv.
-    // @TODO "Lacey: I'm concerned this might be a point of slowness. Perhaps there is a better
-    //       way to create CSV that doesn't require fputcsv and is more reliable
-    //       then simply imploding the values with comma's in-between."
-    $file_handle = fopen($file_name, 'a');
-    
-    // Since we want to insert values, we can merge our values to have all the information we need and then write to the file.
-    $values = array_merge($select_values, $insert_values);
-    ksort($values); // to ensure they're always in the same order.
-    fputcsv($file_handle, $values);
-    
-    return TRUE;
-    
-  }
-  
-  // Else if the mode is insert & select, or select only, insert one record at a time
-  else {
-    
-    // First we select the record to see if it already exists.
-    $record = chado_select_record($table, array($pkey), $select_values); 
-    
-    // If it exists then return the primary key
-    if (sizeof($record) == 1) {
+    // Otherwise the mode allows select so return the value of the primary key.
+    else {
       return $record[0]->{$pkey};
     }
+  }
     
-    // If more then one result is returned then this is NOT UNIQUE and we should report an
-    // error to the user - not just run with the first one.
-    elseif (sizeof($record) > 1) {
-      return drush_set_error(dt('Record "@record_type" is not unique. (mode=@mode). Values: ', array('@record_type' => $record_type, '@mode' => $mode)).print_r($values,TRUE));
+  // If more then one result is returned then this is NOT UNIQUE and we should report an
+  // error to the user - not just run with the first one.
+  elseif (sizeof($record) > 1) {
+    return drush_set_error(dt('Record "@record_type" is not unique. (mode=@mode). Values: ', array('@record_type' => $record_type, '@mode' => $mode)).print_r($select_values,TRUE));
+  }
+  
+  // If there is no pre-existing sample but we've been given permission to create it,
+  // then insert it
+  elseif ($mode == $both) {
+    
+    // If we want to insert values, we can merge our values to have all the information we need
+    $values = array_merge($select_values, $insert_values);
+    
+    $record = chado_insert_record($table, $values);
+    
+    // If the primary key is available then the insert worked and we can return it.
+    if (isset($record[$pkey])) {
+      return $record[$pkey];
     }
-    // If there is no pre-existing sample but we've been given permission to create it,
-    // then insert it
-    elseif ($mode == $both) {
-      
-      // If we want to insert values, we can merge our values to have all the information we need
-      $values = array_merge($select_values, $insert_values);
-      
-      $record = chado_insert_record($table, $values);
-      
-      // If the primary key is available then the insert worked and we can return it.
-      if (isset($record[$pkey])) {
-        return $record[$pkey];
-      }
-      // Otherwise, something went wrong so tell the user
-      else {
-        return drush_set_error(dt('Tried to insert "@record_type" but the primary key is returned empty (mode=@mode). Values: ', array('@record_type' => $record_type, '@mode' => $mode)).print_r($values,TRUE));
-      }
-    }
-    // If there is no pre-existing record and we are not allowed to create one
-    // then return an error.
+    // Otherwise, something went wrong so tell the user
     else {
-      return drush_set_error(dt('Record "@record_type" doesn\'t already exist but you chose to only select (mode=@mode). Values: ', array('@record_type' => $record_type, '@mode' => $mode)).print_r($values,TRUE));
+      return drush_set_error(dt('Tried to insert "@record_type" but the primary key is returned empty (mode=@mode). Values: ', array('@record_type' => $record_type, '@mode' => $mode)).print_r($values,TRUE));
     }
   }
+  // If there is no pre-existing record and we are not allowed to create one
+  // then return an error.
+  else {
+    return drush_set_error(dt('Record "@record_type" doesn\'t already exist but you chose to only select (mode=@mode). Values: ', array('@record_type' => $record_type, '@mode' => $mode)).print_r($values,TRUE));
+  }
 }
+
+/**
+ * This function will copy into the database the the last remaining chunk of insert-only records
+ * 
+ * @param $record_type
+ *   A human-readable term for your record for error messages.
+ * @param $table
+ *   The chado table to insert into.
+ * @param $insert_values
+ *   An array of [table column] => [value] mappings that is specific to the insert.
+ * @param $record_count
+ *   The current count (less than the copy_chunk_size) of records that are being loaded in.
+ * @param $file_name
+ *   An optional name for the file to write the values to
+ * @return
+ *   TRUE if success, FALSE if failed.
+ */
+
+function genotypes_loader_helper_copy_records($record_type, $table, $insert_values = array(), $record_count = NULL, $file_name = NULL) {
+  
+  // If we weren't given the name of the file to copy from, then try to find it using the record_type and table name
+  // that we were given
+  if ($file_name === NULL) {
+    $file_stub = '/tmp/genotype_loader.';
+    $record_type = str_replace(' ', '_', $record_type);
+    $record_type = strtolower($record_type);
+    $file_name = $file_stub . $table . '-' . $record_type . '.csv';
+  }
+  
+  // Now open the file to write to since this is needed by fputcsv.
+  // @TODO "Lacey: I'm concerned this might be a point of slowness. Perhaps there is a better
+  //       way to create CSV that doesn't require fputcsv and is more reliable
+  //       then simply imploding the values with comma's in-between."
+  $file_handle = fopen($file_name, 'a') or die ("ERROR: Unable to create $file_name to bulk load records!\n");;
+  ksort($insert_values); // to ensure they're always in the same order.
+  fputcsv($file_handle, $values);
+  
+  if ($record_count >= $copy_chunk_size) {
+    // Determine the COPY Command using the keys of the values array (i.e. the fields)
+    // and the file name.
+    
+    // Use drush to determine the connection details and then execute the command.
+    
+  }
+  
+  return TRUE;
+  
+  
+}
+
 
 /**
  * Adds genotype records when using the ND Experiment Tables storage method. This is a

--- a/api/genotypes_loader.api.inc
+++ b/api/genotypes_loader.api.inc
@@ -58,7 +58,7 @@ function genotypes_loader_get_postgresql_version() {
 
 function genotypes_loader_helper_add_record_with_mode($record_type, $table, $mode, $select_values, $insert_values = array(), $file_name = NULL) {
   
-  drush_print("Record type: " . $record_type . ", Mode: " . $mode);
+  //drush_print("Record type: " . $record_type . ", Mode: " . $mode);
   
   // The number of records to copy at once
   $copy_chunk_size = 50000;
@@ -78,21 +78,26 @@ function genotypes_loader_helper_add_record_with_mode($record_type, $table, $mod
     // then we need to determine a file name in a repeatable but unique manner.
     if ($file_name === NULL) {
       $file_stub = '/tmp/genotype_loader.';
-      $file_name = $file_stub . $table . '.csv';
+      $record_type = str_replace(' ', '_', $record_type);
+      $record_type = strtolower($record_type);
+      $file_name = $file_stub . $table . '-' . $record_type . '.csv';
     }
     
-    drush_print("Filename: " . $file_name);
+    //drush_print("Filename: " . $file_name);
     
     // Now open the file to write to since this is needed by fputcsv.
     // @TODO "Lacey: I'm concerned this might be a point of slowness. Perhaps there is a better
     //       way to create CSV that doesn't require fputcsv and is more reliable
     //       then simply imploding the values with comma's in-between."
-    $file_handle = fopen($file_name, 'w');
+    $file_handle = fopen($file_name, 'a');
     
     // Since we want to insert values, we can merge our values to have all the information we need and then write to the file.
     $values = array_merge($select_values, $insert_values);
     ksort($values); // to ensure they're always in the same order.
     fputcsv($file_handle, $values);
+    
+    return TRUE;
+    
   }
   
   // Else if the mode is insert & select, or select only, insert one record at a time

--- a/api/genotypes_loader.api.inc
+++ b/api/genotypes_loader.api.inc
@@ -43,6 +43,8 @@ function genotypes_loader_get_postgresql_version() {
  *   select and the insert.
  * @param $insert_values
  *   An array of [table column] => [value] mappings that is specific to the insert.
+ * @param $file_name
+ *   An optional name for the file to write the values to if mode is insert only
  * @return
  *   The value of the primary key for the inserted/selected record or FALSE if failed.
  */
@@ -54,47 +56,84 @@ function genotypes_loader_get_postgresql_version() {
   *
   */
 
-function genotypes_loader_helper_add_record_with_mode($record_type, $table, $mode, $select_values, $insert_values = array()) {
+function genotypes_loader_helper_add_record_with_mode($record_type, $table, $mode, $select_values, $insert_values = array(), $file_name = NULL) {
+  
+  drush_print("Record type: " . $record_type . ", Mode: " . $mode);
   
   // The number of records to copy at once
   $copy_chunk_size = 50000;
+  
+  // Set some variables to abstract mode
+  $select_only = 0;
+  $insert_only = 1;
+  $both = 2;
   
   // the name of the primary key.
   $pkey = $table . '_id';
   
   // If the mode is insert only, then we should be able to safely copy everything to a file and load in bulk
+  if ($mode == $insert_only) {
+    
+    // If we weren't given the name of the file to write to
+    // then we need to determine a file name in a repeatable but unique manner.
+    if ($file_name === NULL) {
+      $file_stub = '/tmp/genotype_loader.';
+      $file_name = $file_stub . $table . '.csv';
+    }
+    
+    drush_print("Filename: " . $file_name);
+    
+    // Now open the file to write to since this is needed by fputcsv.
+    // @TODO "Lacey: I'm concerned this might be a point of slowness. Perhaps there is a better
+    //       way to create CSV that doesn't require fputcsv and is more reliable
+    //       then simply imploding the values with comma's in-between."
+    $file_handle = fopen($file_name, 'w');
+    
+    // Since we want to insert values, we can merge our values to have all the information we need and then write to the file.
+    $values = array_merge($select_values, $insert_values);
+    ksort($values); // to ensure they're always in the same order.
+    fputcsv($file_handle, $values);
+  }
   
   // Else if the mode is insert & select, or select only, insert one record at a time
-  
-  // First we select the record to see if it already exists.
-  $record = chado_select_record($table, array($pkey), $select_values);
-  // If we want to insert values, we can merge our values to have all the information we need
-  $values = array_merge($select_values, $insert_values);
-  // If it exists and the mode is 1 (Insert Only) then return an error to drush.
-  if (sizeof($record) == 1) {
-    if ($mode == 1) {
-      return drush_set_error(dt('Record "@record_type" already exists but you chose to only insert (mode=@mode). Values: ', array('@record_type' => $record_type, '@mode' => $mode)).print_r($values,TRUE));
-    }
-    // Otherwise the mode allows select so return the value of the primary key.
-    else {
+  else {
+    
+    // First we select the record to see if it already exists.
+    $record = chado_select_record($table, array($pkey), $select_values); 
+    
+    // If it exists then return the primary key
+    if (sizeof($record) == 1) {
       return $record[0]->{$pkey};
     }
-  }
-  // If more then one result is returned then this is NOT UNIQUE and we should report an
-  // error to the user -not just run with the first one.
-  elseif (sizeof($record) > 1) {
-    return drush_set_error(dt('Record "@record_type" is not unique. (mode=@mode). Values: ', array('@record_type' => $record_type, '@mode' => $mode)).print_r($values,TRUE));
-  }
-  // If there is no pre-existing sample but we've been given permission to create it,
-  // then we will insert it :-).
-  elseif ($mode) {
-    $record = chado_insert_record($table, $values);
-    return $record[$pkey];
-  }
-  // If there is no pre-existing record and we are not allowed to create one
-  // then return an error.
-  else {
-    return drush_set_error(dt('Record "@record_type" doesn\'t already exist but you chose to only select (mode=@mode). Values: ', array('@record_type' => $record_type, '@mode' => $mode)).print_r($values,TRUE));
+    
+    // If more then one result is returned then this is NOT UNIQUE and we should report an
+    // error to the user - not just run with the first one.
+    elseif (sizeof($record) > 1) {
+      return drush_set_error(dt('Record "@record_type" is not unique. (mode=@mode). Values: ', array('@record_type' => $record_type, '@mode' => $mode)).print_r($values,TRUE));
+    }
+    // If there is no pre-existing sample but we've been given permission to create it,
+    // then insert it
+    elseif ($mode == $both) {
+      
+      // If we want to insert values, we can merge our values to have all the information we need
+      $values = array_merge($select_values, $insert_values);
+      
+      $record = chado_insert_record($table, $values);
+      
+      // If the primary key is available then the insert worked and we can return it.
+      if (isset($record[$pkey])) {
+        return $record[$pkey];
+      }
+      // Otherwise, something went wrong so tell the user
+      else {
+        return drush_set_error(dt('Tried to insert "@record_type" but the primary key is returned empty (mode=@mode). Values: ', array('@record_type' => $record_type, '@mode' => $mode)).print_r($values,TRUE));
+      }
+    }
+    // If there is no pre-existing record and we are not allowed to create one
+    // then return an error.
+    else {
+      return drush_set_error(dt('Record "@record_type" doesn\'t already exist but you chose to only select (mode=@mode). Values: ', array('@record_type' => $record_type, '@mode' => $mode)).print_r($values,TRUE));
+    }
   }
 }
 

--- a/api/genotypes_loader.api.inc
+++ b/api/genotypes_loader.api.inc
@@ -154,7 +154,6 @@ function genotypes_loader_helper_copy_records($record_count, $record_type, $tabl
     //$copy_command = 'COPY chado.' . $table . ' (' . implode(',', array_keys($values) . ") FROM '$file_name' WITH CSV";
     //drush_print("The copy command: " . $copy_command);
     
-    // Use drush to determine the connection details and then execute the command.
     fclose($file_handle);
     drush_print("Yippee, copying in " . $record_count . " records now!");
     
@@ -165,12 +164,50 @@ function genotypes_loader_helper_copy_records($record_count, $record_type, $tabl
   
   return TRUE;
   
-  
 }
 
-function genotypes_loader_execute_copy_command($copy_command) {
-
-  // Use drush to determine the connection details and then execute the command.
+/**
+ * Uses drush to safely copy data quickly. ONLY USE IN TRIPAL JOBS!!
+ *
+ * PostgreSQL COPY is extremely effective at copying/inserting large amount of
+ * data. This modules uses it to create materialized views to cache queries
+ * for faster data access. However, using chado_query('COPY...') poses many
+ * security risks in a web setting. We use a combination of drush sql-cli,
+ * which opens a psql session, and psql's \copy command to take advantage of
+ * the fact that Tripal Jobs are run on the command-line.
+ *
+ * @param $copy_command
+ *   The full PostgreSQL copy command to be executed.
+ */
+function genotypes_loader_remote_copy($copy_command) {
+  /**
+   * The following is the remote copy function used by the nd_genotypes module
+   * 
+  // Prefix the tables with their correct schema.
+  // Chado tables should be enclosed in curly brackets (ie: {feature} )
+  // and Drupal tables should be enclosed in square brackets (ie: [tripal_jobs] ).
+  $chado_schema_name = tripal_get_schema_name('chado');
+  $drupal_schema_name = tripal_get_schema_name('drupal');
+  $copy_command = preg_replace('/\{(.*?)\}/', $chado_schema_name.'.$1', $copy_command);
+  $copy_command = preg_replace('/\[(\w+)\]/', $drupal_schema_name.'.$1', $copy_command);
+  // Substitute any arguements for placeholders.
+  foreach ($args as $k => $v) {
+    if (is_string($v)) {
+      $args[$k] = "'" . $v . "'";
+    }
+  }
+  $copy_command = strtr($copy_command, $args);
+  // Allow the same hooks that act on chado_query to act on this query.
+  drupal_alter('chado_query', $copy_command, $args);
+  // Execute the command within a drush created psql session using \COPY.
+  return drush_invoke_process(
+    '@self',
+    'sql-cli',
+    array(),
+    array('extra' => '--command="\\'.$copy_command.'"')
+  );
+  */
+  
 }
 
 

--- a/api/genotypes_loader.api.inc
+++ b/api/genotypes_loader.api.inc
@@ -132,10 +132,15 @@ function genotypes_loader_helper_copy_records($record_count, $record_type, $tabl
   // If we weren't given the name of the file to copy from, then try to find it using the record_type and table name
   // that we were given
   if ($file_name === NULL) {
+    // Pull out the name of the database to ensure the file is not overwritten by a concurrent upload
+    // to another database
+    global $databases;
+    $db_name = $databases['default']['default']['database'];
+
     $file_stub = '/tmp/genotype_loader.';
     $record_type = str_replace(' ', '_', $record_type);
     $record_type = strtolower($record_type);
-    $file_name = $file_stub . $table . '-' . $record_type . '.csv';
+    $file_name = $file_stub . $db_name . '-' . $table . '-' . $record_type . '.remotecopy.csv';
   }
 
   // If this is the last chunk to be entered into the database, then we don't have a record to add to the file.

--- a/api/genotypes_loader.api.inc
+++ b/api/genotypes_loader.api.inc
@@ -110,24 +110,25 @@ function genotypes_loader_helper_add_record_with_mode($record_type, $table, $mod
 }
 
 /**
- * This function will copy into the database the the last remaining chunk of insert-only records
+ * Places records into a CSV file, and then checks if it is time to bulk load the file via a COPY command
  * 
+ * @param $record_count
+ *   The current count (less than the copy_chunk_size) of records that are being loaded in.
  * @param $record_type
  *   A human-readable term for your record for error messages.
  * @param $table
  *   The chado table to insert into.
  * @param $insert_values
  *   An array of [table column] => [value] mappings that is specific to the insert.
- * @param $record_count
- *   The current count (less than the copy_chunk_size) of records that are being loaded in.
  * @param $file_name
  *   An optional name for the file to write the values to
  * @return
- *   TRUE if success, FALSE if failed.
+ *   TRUE if success (meaning, we reached the end of the function, not neccesarily that everything went swimmingly), FALSE if failed.
  */
 
-function genotypes_loader_helper_copy_records($record_type, $table, $insert_values = array(), $record_count = NULL, $file_name = NULL) {
+function genotypes_loader_helper_copy_records($record_count, $record_type, $table, $insert_values = array(), $file_name = NULL) {
   
+  // The number of records we want to reach before copying them in all at once
   $copy_chunk_size = 5;
   
   // If we weren't given the name of the file to copy from, then try to find it using the record_type and table name
@@ -150,11 +151,14 @@ function genotypes_loader_helper_copy_records($record_type, $table, $insert_valu
   if ($record_count%$copy_chunk_size == 0) {
     // Determine the COPY Command using the keys of the values array (i.e. the fields)
     // and the file name.
+    //$copy_command = 'COPY chado.' . $table . ' (' . implode(',', array_keys($values) . ") FROM '$file_name' WITH CSV";
+    //drush_print("The copy command: " . $copy_command);
     
     // Use drush to determine the connection details and then execute the command.
-    
-    drush_print("Yippee, copying in " . $record_count . " records now!");
     fclose($file_handle);
+    drush_print("Yippee, copying in " . $record_count . " records now!");
+    
+    // Wipe the file clean by reopening it as write-only
     $file_handle = fopen($file_name, 'w');
     //fclose($file_handle);
   }
@@ -163,6 +167,13 @@ function genotypes_loader_helper_copy_records($record_type, $table, $insert_valu
   
   
 }
+
+function genotypes_loader_execute_copy_command($copy_command) {
+
+  // Use drush to determine the connection details and then execute the command.
+}
+
+
 
 
 /**

--- a/api/genotypes_loader.api.inc
+++ b/api/genotypes_loader.api.inc
@@ -6,7 +6,7 @@
 
 /**
  * Determines the correct postgreSQL version, otherwise assumes version 9.2.
- * 
+ *
  * @return
  *   The numbered version of PostgreSQL (ex. 9.2, 9.3, etc)
  */
@@ -17,7 +17,7 @@ function genotypes_loader_recheck_postgresql_version() {
     $version = $matches[1];
   }
   variable_set('pgsql_version', $version);
-  
+
   return $version;
 }
 
@@ -55,18 +55,18 @@ function genotypes_loader_get_postgresql_version() {
   */
 
 function genotypes_loader_helper_add_record_with_mode($record_type, $table, $mode, $select_values, $insert_values = array()) {
-  
+
   // Set some variables to abstract mode
   $select_only = 0;
   $insert_only = 1;
   $both = 2;
-  
+
   // the name of the primary key.
   $pkey = $table . '_id';
-      
+
   // First we select the record to see if it already exists.
-  $record = chado_select_record($table, array($pkey), $select_values); 
-  
+  $record = chado_select_record($table, array($pkey), $select_values);
+
   // If it exists and the mode is 1 (Insert Only) then return an error to drush.
   if (sizeof($record) == 1) {
     if ($mode == $insert_only) {
@@ -77,22 +77,22 @@ function genotypes_loader_helper_add_record_with_mode($record_type, $table, $mod
       return $record[0]->{$pkey};
     }
   }
-    
+
   // If more then one result is returned then this is NOT UNIQUE and we should report an
   // error to the user - not just run with the first one.
   elseif (sizeof($record) > 1) {
     return drush_set_error(dt('Record "@record_type" is not unique. (mode=@mode). Values: ', array('@record_type' => $record_type, '@mode' => $mode)).print_r($select_values,TRUE));
   }
-  
+
   // If there is no pre-existing sample but we've been given permission to create it,
   // then insert it
   elseif ($mode == $both) {
-    
+
     // If we want to insert values, we can merge our values to have all the information we need
     $values = array_merge($select_values, $insert_values);
-    
+
     $record = chado_insert_record($table, $values);
-    
+
     // If the primary key is available then the insert worked and we can return it.
     if (isset($record[$pkey])) {
       return $record[$pkey];
@@ -111,7 +111,7 @@ function genotypes_loader_helper_add_record_with_mode($record_type, $table, $mod
 
 /**
  * Places records into a CSV file, and then checks if it is time to bulk load the file via a COPY command
- * 
+ *
  * @param $record_count
  *   The current count of records that are being loaded in.
  * @param $record_type
@@ -129,10 +129,10 @@ function genotypes_loader_helper_add_record_with_mode($record_type, $table, $mod
  */
 
 function genotypes_loader_helper_copy_records($record_count, $record_type, $table, $insert_values = array(), $file_name = NULL, $final_chunk = FALSE) {
-  
+
   // The number of records we want to reach before copying them in all at once
-  $copy_chunk_size = 5;
-  
+  $copy_chunk_size = 10000;
+
   // If we weren't given the name of the file to copy from, then try to find it using the record_type and table name
   // that we were given
   if ($file_name === NULL) {
@@ -141,7 +141,7 @@ function genotypes_loader_helper_copy_records($record_count, $record_type, $tabl
     $record_type = strtolower($record_type);
     $file_name = $file_stub . $table . '-' . $record_type . '.csv';
   }
-  
+
   // If this is the last chunk to be entered into the database, then we don't have a record to add to the file.
   // Otherwise, open the file to write to since this is needed by fputcsv.
   // @TODO "Lacey: I'm concerned this might be a point of slowness. Perhaps there is a better
@@ -157,7 +157,7 @@ function genotypes_loader_helper_copy_records($record_count, $record_type, $tabl
     fputcsv($file_handle, $insert_values);
     fclose($file_handle);
   }
-  
+
   if (($record_count%$copy_chunk_size == 0) || ($final_chunk)) {
     // Write out the COPY command
     // Columns are listed in alphabetical order because we used ksort() before printing the values to a file.
@@ -171,16 +171,16 @@ function genotypes_loader_helper_copy_records($record_count, $record_type, $tabl
       FROM STDIN WITH CSV";
 
     genotypes_loader_remote_copy($copy_command, $file_name);
-    
+
     // Wipe the file clean by reopening it as write-only
     $file_handle = fopen($file_name, 'w');
     fclose($file_handle);
-    
+
     drush_log("Copied in " . $record_count . " records.");
   }
-  
+
   return TRUE;
-  
+
 }
 
 /**
@@ -199,24 +199,15 @@ function genotypes_loader_helper_copy_records($record_count, $record_type, $tabl
  *   The name of the file from which COPY gets its contents to copy into the database
  */
 function genotypes_loader_remote_copy($copy_command, $file_name) {
-  
-  // Execute the command within a drush created psql session using \COPY.
+
+  // Setup the command within a drush created psql session using \COPY.
   $connection_string = `drush sql-connect`;
   $connection_string = trim($connection_string);
   $command = $connection_string . ' -c "\\' . $copy_command . '" < ' . $file_name;
-  
+
   // Execute the command
-  //return `$command`;
-  drush_print("The copy command: " . $command);
-  
-  
-  /*return drush_invoke_process(
-    '@self',
-    'sql-cli',
-    array(),
-    array('extra' => '--command="\\'.$copy_command.'"')
-  );
-  */
+  return `$command`;
+
 }
 
 
@@ -364,10 +355,10 @@ function genotypes_loader_helper_add_genotypes_genotype_call($v, $num_calls = 0,
     'stock_id' => $v['stock_id'],
     'meta_data' => $v['meta_data'],
   );
-  
+
   $status = genotypes_loader_helper_copy_records($num_calls, 'Genotype Call', 'genotype_call', $insert_values, $file_name);
-  
-  
+
+
 //  $genotype_call_id = genotypes_loader_helper_add_record_with_mode('Genotype Call', 'genotype_call', $both, $select_values, $insert_values);
 //  if (!$genotype_call_id) return FALSE;
 

--- a/api/genotypes_loader.api.inc
+++ b/api/genotypes_loader.api.inc
@@ -128,6 +128,8 @@ function genotypes_loader_helper_add_record_with_mode($record_type, $table, $mod
 
 function genotypes_loader_helper_copy_records($record_type, $table, $insert_values = array(), $record_count = NULL, $file_name = NULL) {
   
+  $copy_chunk_size = 5;
+  
   // If we weren't given the name of the file to copy from, then try to find it using the record_type and table name
   // that we were given
   if ($file_name === NULL) {
@@ -143,14 +145,18 @@ function genotypes_loader_helper_copy_records($record_type, $table, $insert_valu
   //       then simply imploding the values with comma's in-between."
   $file_handle = fopen($file_name, 'a') or die ("ERROR: Unable to create $file_name to bulk load records!\n");;
   ksort($insert_values); // to ensure they're always in the same order.
-  fputcsv($file_handle, $values);
+  fputcsv($file_handle, $insert_values);
   
-  if ($record_count >= $copy_chunk_size) {
+  if ($record_count%$copy_chunk_size == 0) {
     // Determine the COPY Command using the keys of the values array (i.e. the fields)
     // and the file name.
     
     // Use drush to determine the connection details and then execute the command.
     
+    drush_print("Yippee, copying in " . $record_count . " records now!");
+    fclose($file_handle);
+    $file_handle = fopen($file_name, 'w');
+    //fclose($file_handle);
   }
   
   return TRUE;
@@ -272,7 +278,7 @@ function genotypes_loader_helper_add_genotypes_nd_exp($v) {
  * @return
  *   TRUE if successful and FALSE otherwise.
  */
-function genotypes_loader_helper_add_genotypes_genotype_call($v) {
+function genotypes_loader_helper_add_genotypes_genotype_call($v, $num_calls = 0) {
 
   // Set some variables to abstract mode for genotypes_loader_helper_add_record_with_mode().
   $select_only = 0;
@@ -286,22 +292,23 @@ function genotypes_loader_helper_add_genotypes_genotype_call($v) {
     'description' => $v['allele'],
     'type_id' => $v['variant_type_id'],
   ));
-  if (!$genotype_id) return FALSE;
+  if (!$genotype_id) return drush_set_error(dt('ERROR: Could not insert the genotype into the genotype table. Values: ', array('@record_type' => $record_type, '@mode' => $mode)).print_r($values,TRUE));
 
-  // Genotype Call
-  $select_values = array(
+  // Enter the genotype call by adding to a file and copy in as a batch
+  $insert_values = array(
     'variant_id' => $v['variant_id'],
     'marker_id' => $v['marker_id'],
     'genotype_id' => $genotype_id,
     'project_id' => $v['project_id'],
     'stock_id' => $v['stock_id'],
-  );
-  $insert_values = array(
     'meta_data' => $v['meta_data'],
   );
   
-  $genotype_call_id = genotypes_loader_helper_add_record_with_mode('Genotype Call', 'genotype_call', $both, $select_values, $insert_values);
-  if (!$genotype_call_id) return FALSE;
+  $status = genotypes_loader_helper_copy_records('Genotype Call', 'genotype_call', $insert_values, $num_calls);
+  
+  
+//  $genotype_call_id = genotypes_loader_helper_add_record_with_mode('Genotype Call', 'genotype_call', $both, $select_values, $insert_values);
+//  if (!$genotype_call_id) return FALSE;
 
   return TRUE;
 }

--- a/api/genotypes_loader.api.inc
+++ b/api/genotypes_loader.api.inc
@@ -164,8 +164,6 @@ function genotypes_loader_helper_copy_records($record_count, $record_type, $tabl
     //$copy_command = 'COPY {' . $table . '} (' . implode(',', array_keys($values) . ") FROM '$file_name' WITH CSV";
     //drush_print("The copy command: " . $copy_command);
     
-    drush_print("Yippee, copying in " . $record_count . " records now!");
-    
     // Wipe the file clean by reopening it as write-only
     $file_handle = fopen($file_name, 'w');
     fclose($file_handle);
@@ -314,10 +312,14 @@ function genotypes_loader_helper_add_genotypes_nd_exp($v) {
  *    - stock_name: the name of the sample.
  *    - allele: the allele call.
  *    - meta_data: any additional data associated with a genotype, in the format of a JSON blob
+ * @param $num_calls
+ *   The number of genotype calls processed so far
+ * @param $file_name
+ *   The name of the output file for records to be inserted into the database in batches
  * @return
  *   TRUE if successful and FALSE otherwise.
  */
-function genotypes_loader_helper_add_genotypes_genotype_call($v, $num_calls = 0) {
+function genotypes_loader_helper_add_genotypes_genotype_call($v, $num_calls = 0, $file_name = NULL) {
 
   // Set some variables to abstract mode for genotypes_loader_helper_add_record_with_mode().
   $select_only = 0;
@@ -343,7 +345,7 @@ function genotypes_loader_helper_add_genotypes_genotype_call($v, $num_calls = 0)
     'meta_data' => $v['meta_data'],
   );
   
-  $status = genotypes_loader_helper_copy_records($num_calls, 'Genotype Call', 'genotype_call', $insert_values);
+  $status = genotypes_loader_helper_copy_records($num_calls, 'Genotype Call', 'genotype_call', $insert_values, $file_name);
   
   
 //  $genotype_call_id = genotypes_loader_helper_add_record_with_mode('Genotype Call', 'genotype_call', $both, $select_values, $insert_values);

--- a/includes/genotypes_loader.vcf.inc
+++ b/includes/genotypes_loader.vcf.inc
@@ -51,10 +51,14 @@ function genotypes_loader_load_VCF($input_file = NULL, $options, $types) {
   $select_only = 0;
   $insert_only = 1;
   $both = 2;
-  
+
   // Set the file name to be used for remote copy
   if ($options['storage_method'] == 'genotype_call') {
-    $remote_copy_filename = '/tmp/genotypes_loader.remotecopy.csv';
+    // Pull out the name of the database to ensure the file is not overwritten by a concurrent upload
+    // to another database (yes, I speak from experience)
+    global $databases;
+    $db_name = $databases['default']['default']['database'];
+    $remote_copy_filename = '/tmp/genotypes_loader.' . $db_name . '.remotecopy.csv';
   }
 
   // -------------------------
@@ -80,7 +84,7 @@ function genotypes_loader_load_VCF($input_file = NULL, $options, $types) {
   // Start the progress bar
   $progress = genotypes_loader_print_progress($num_lines, $total_lines);
   print($progress);
-  
+
   // Start the counter for number of (non-empty) genotypic calls
   $num_calls = 0;
 
@@ -258,7 +262,7 @@ function genotypes_loader_load_VCF($input_file = NULL, $options, $types) {
       // If $allele is empty, it means we have missing data for this genotype (ie. ./.)
       // Thus, skip this particular genotype and move onto the next.
       if (!$allele) { continue; }
-      
+
       // Since it is non-empty, increment the genotype call count
       $num_calls++;
 
@@ -300,13 +304,13 @@ function genotypes_loader_load_VCF($input_file = NULL, $options, $types) {
     $progress = genotypes_loader_print_progress($num_lines, $total_lines);
     print($progress);
   }
-  
+
   // Since we finished inserting the calls, we may want to clean up if we were using the COPY method
   if ($options['storage_method'] == 'genotype_call') {
     drush_print("\nCopying in the final batch of calls...");
     $status = genotypes_loader_helper_copy_records($num_calls, NULL, NULL, array(), $remote_copy_filename, TRUE);
   }
-  
+
   // If we got here without returning an error then we completed successfully!
   drush_log("Loading Complete.", "success");
 

--- a/includes/genotypes_loader.vcf.inc
+++ b/includes/genotypes_loader.vcf.inc
@@ -51,6 +51,11 @@ function genotypes_loader_load_VCF($input_file = NULL, $options, $types) {
   $select_only = 0;
   $insert_only = 1;
   $both = 2;
+  
+  // Set the file name to be used for remote copy
+  if ($options['storage_method'] == 'genotype_call') {
+    $remote_copy_filename = '/tmp/genotypes_loader.remotecopy.csv';
+  }
 
   // -------------------------
   //    PROCESSING VCF FILE
@@ -276,7 +281,7 @@ function genotypes_loader_load_VCF($input_file = NULL, $options, $types) {
       // Insert genotypes based on the preferred storage method
       if ($options['storage_method'] == 'genotype_call') {
         $fields['meta_data'] = json_encode($metadata);
-        $status = genotypes_loader_helper_add_genotypes_genotype_call($fields, $num_calls);
+        $status = genotypes_loader_helper_add_genotypes_genotype_call($fields, $num_calls, $remote_copy_filename);
       }
       // @TODO: ND genotypes option - deprecating this in the future?
       else if ($options['storage_method'] == 'nd_geolocation') {
@@ -298,7 +303,8 @@ function genotypes_loader_load_VCF($input_file = NULL, $options, $types) {
   
   // Since we finished inserting the calls, we may want to clean up if we were using the COPY method
   if ($options['storage_method'] == 'genotype_call') {
-     $status = genotypes_loader_helper_copy_records($num_calls, NULL, NULL, array(), NULL, TRUE);
+    drush_print("\nCopying in the final batch of calls...");
+    $status = genotypes_loader_helper_copy_records($num_calls, NULL, NULL, array(), $remote_copy_filename, TRUE);
   }
   
   // If we got here without returning an error then we completed successfully!

--- a/includes/genotypes_loader.vcf.inc
+++ b/includes/genotypes_loader.vcf.inc
@@ -58,7 +58,8 @@ function genotypes_loader_load_VCF($input_file = NULL, $options, $types) {
     // to another database (yes, I speak from experience)
     global $databases;
     $db_name = $databases['default']['default']['database'];
-    $remote_copy_filename = '/tmp/genotypes_loader.' . $db_name . '.remotecopy.csv';
+    $table_name = 'genotype_call';
+    $remote_copy_filename = '/tmp/genotypes_loader.' . $db_name . '-' . $table_name . '.remotecopy.csv';
   }
 
   // -------------------------

--- a/includes/genotypes_loader.vcf.inc
+++ b/includes/genotypes_loader.vcf.inc
@@ -273,9 +273,19 @@ function genotypes_loader_load_VCF($input_file = NULL, $options, $types) {
         'allele' => $allele,
       );
 
-      if (isset($options['nd_geolocation'])) $fields['nd_geolocation'] = $options['nd_geolocation'];
-      if ($options['storage_method'] == 'genotype_call') $fields['meta_data'] = json_encode($metadata);
-      $status = call_user_func('genotypes_loader_helper_add_genotypes_'.$options['storage_method'], $fields, $num_calls);
+      // Insert genotypes based on the preferred storage method
+      // @TODO: ND genotypes option - deprecating this in the future?
+      if ($options['storage_method'] == 'nd_geolocation') {
+        $fields['nd_geolocation'] = $options['nd_geolocation'];
+        $status = genotypes_loader_helper_add_genotypes_nd_exp($fields);
+      }
+      else if ($options['storage_method'] == 'genotype_call') {
+        $fields['meta_data'] = json_encode($metadata);
+        $status = genotypes_loader_helper_add_genotypes_genotype_call($fields, $num_calls);
+      }
+      else if ($options['storage_method'] == 'stock_genotype') {
+        $status = genotypes_loader_helper_add_genotypes_stock_genotype($fields);
+      }
       // @TODO: Return a useful error message
       if (!$status) { return FALSE; }
     }
@@ -285,6 +295,12 @@ function genotypes_loader_load_VCF($input_file = NULL, $options, $types) {
     $progress = genotypes_loader_print_progress($num_lines, $total_lines);
     print($progress);
   }
+  
+  // Since we finished inserting the calls, we may want to clean up if we were using the COPY method
+  if ($options['storage_method'] == 'genotype_call') {
+     $status = genotypes_loader_helper_add_genotypes_copy_records($num_calls);
+  }
+  
   // If we got here without returning an error then we completed successfully!
   drush_log("Loading Complete.", "success");
 

--- a/includes/genotypes_loader.vcf.inc
+++ b/includes/genotypes_loader.vcf.inc
@@ -298,7 +298,7 @@ function genotypes_loader_load_VCF($input_file = NULL, $options, $types) {
   
   // Since we finished inserting the calls, we may want to clean up if we were using the COPY method
   if ($options['storage_method'] == 'genotype_call') {
-//     $status = genotypes_loader_helper__copy_records($num_calls);
+     $status = genotypes_loader_helper_copy_records($num_calls, NULL, NULL, array(), NULL, TRUE);
   }
   
   // If we got here without returning an error then we completed successfully!

--- a/includes/genotypes_loader.vcf.inc
+++ b/includes/genotypes_loader.vcf.inc
@@ -274,14 +274,14 @@ function genotypes_loader_load_VCF($input_file = NULL, $options, $types) {
       );
 
       // Insert genotypes based on the preferred storage method
-      // @TODO: ND genotypes option - deprecating this in the future?
-      if ($options['storage_method'] == 'nd_geolocation') {
-        $fields['nd_geolocation'] = $options['nd_geolocation'];
-        $status = genotypes_loader_helper_add_genotypes_nd_exp($fields);
-      }
-      else if ($options['storage_method'] == 'genotype_call') {
+      if ($options['storage_method'] == 'genotype_call') {
         $fields['meta_data'] = json_encode($metadata);
         $status = genotypes_loader_helper_add_genotypes_genotype_call($fields, $num_calls);
+      }
+      // @TODO: ND genotypes option - deprecating this in the future?
+      else if ($options['storage_method'] == 'nd_geolocation') {
+        $fields['nd_geolocation'] = $options['nd_geolocation'];
+        $status = genotypes_loader_helper_add_genotypes_nd_exp($fields);
       }
       else if ($options['storage_method'] == 'stock_genotype') {
         $status = genotypes_loader_helper_add_genotypes_stock_genotype($fields);

--- a/includes/genotypes_loader.vcf.inc
+++ b/includes/genotypes_loader.vcf.inc
@@ -75,6 +75,9 @@ function genotypes_loader_load_VCF($input_file = NULL, $options, $types) {
   // Start the progress bar
   $progress = genotypes_loader_print_progress($num_lines, $total_lines);
   print($progress);
+  
+  // Start the counter for number of (non-empty) genotypic calls
+  $num_calls = 0;
 
   // Now going line by line to pull out the marker, then genotypes.
   while(!feof($VCFfile)) {
@@ -250,6 +253,9 @@ function genotypes_loader_load_VCF($input_file = NULL, $options, $types) {
       // If $allele is empty, it means we have missing data for this genotype (ie. ./.)
       // Thus, skip this particular genotype and move onto the next.
       if (!$allele) { continue; }
+      
+      // Since it is non-empty, increment the genotype call count
+      $num_calls++;
 
       $fields = array(
         'project_id' => $options['project_id'],
@@ -269,7 +275,7 @@ function genotypes_loader_load_VCF($input_file = NULL, $options, $types) {
 
       if (isset($options['nd_geolocation'])) $fields['nd_geolocation'] = $options['nd_geolocation'];
       if ($options['storage_method'] == 'genotype_call') $fields['meta_data'] = json_encode($metadata);
-      $status = call_user_func('genotypes_loader_helper_add_genotypes_'.$options['storage_method'], $fields);
+      $status = call_user_func('genotypes_loader_helper_add_genotypes_'.$options['storage_method'], $fields, $num_calls);
       // @TODO: Return a useful error message
       if (!$status) { return FALSE; }
     }

--- a/includes/genotypes_loader.vcf.inc
+++ b/includes/genotypes_loader.vcf.inc
@@ -298,7 +298,7 @@ function genotypes_loader_load_VCF($input_file = NULL, $options, $types) {
   
   // Since we finished inserting the calls, we may want to clean up if we were using the COPY method
   if ($options['storage_method'] == 'genotype_call') {
-     $status = genotypes_loader_helper_add_genotypes_copy_records($num_calls);
+//     $status = genotypes_loader_helper__copy_records($num_calls);
   }
   
   // If we got here without returning an error then we completed successfully!


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- No need to include the issue number in the title :-) -->
          
<!--- If it fixes an open issue, please add the issue link below. -->
Issue #4 

## Description
<!--- Describe your changes in detail -->
2 new functions were added to the API to handle copying in of genotypic calls from VCF format to the genotype_call table. I opted for the COPY method as per Lacey's suggestion. Genotype calls get saved to a CSV file and loaded into the database once 10,000 records are reached. Rinse and repeat until all calls are loaded. The module ensures that any calls remaining in the file once the VCF is fully processed will also get loaded into the database.
<!--- Why is this change required? What problem does it solve? -->
This change was crucial to ensure we can load enormous amounts of genotypic data in a reasonable amount of time. ;-) 

Please note the following:
- Testing with very large datasets is currently in progress, and further optimization may be required
- This functionality is currently specific to the genotype_call table method ONLY, and will only work for VCF file inputs (implementing this for the other input formats should be trivial however - let me know if there is demand for this!)

## Testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how
      your change affects other areas of the code, etc. -->
I implemented my changes in a cloud9 environment (see Pull Request #18 for how I set up my environment), however cloud9 appears to struggle with command-line execution of the copy command (also Lacey's experience). My final testing took place on the clone site using cats.list and cats.vcf as my input files. No cvterms need to be added/configured, but I added organisms, chromosome and project as demonstrated in #18. I also set up a .pgpass file in my home directory with connection details to the clone's database (see https://gist.github.com/sabman/978352). This is to ensure you don't get prompted for a connection password for every batch being loaded in (this step is technically optional, as the functionality still works, but annoying if omitted). I loaded genotypes using the command: 
`drush load-genotypes sample_files/cats.vcf sample_files/cats.list --marker-type="genetic_marker" --variant-type="SNP" --organism="Felis catus" --project-name="My SNP Discovery Project" --ndgeolocation="here"`

At present, I tested where copy_chunk_size is greater and less than the number of records I expect (with cats.vcf: 22 records expected). More test cases to be reported soon! For now, a code review would be immensely helpful 😊