### PR TITLE
Updated the metadata regex to also match floating points

### DIFF
--- a/includes/genotypes_loader.vcf.inc
+++ b/includes/genotypes_loader.vcf.inc
@@ -230,7 +230,7 @@ function genotypes_loader_load_VCF($input_file = NULL, $options, $types) {
       $metadata = array();
       foreach ($format_keys as $subfield) {
         // We are already saving the genotype, so ignore GT. Also, ignore any subfields with missing data.
-        if (($subfield != 'GT') && (!preg_match('/\./', $marker[$source_name][$subfield]))) {
+        if (($subfield != 'GT') && (preg_match('/\b\.*\b/', $marker[$source_name][$subfield]))) {
           $metadata[$subfield] = $marker[$source_name][$subfield];
         }
       }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- No need to include the issue number in the title :-) -->

## Metadata
<!--- If it fixes an open issue, please add the issue link below. -->
 - Issue #29 

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I feel this PR is ready to be merged.
- [ ] This PR is dependent upon [PR #/ nothing]

Documentation:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Previously, any presence of a `.` was ignored in VCF subfields. Since floating point values as metadata can be valid, I altered the regex (thanks to help from @laceysanderson!) to capture floating points in addition to integers and strings, but still reject missing data (ie. `.` or `.,.`, etc...)

## Dependencies
<!-- If this code is dependent upon another module and/or PR, 
       state that here. -->
<!-- Include information about other modules/PRs needed for testing,
        which to enable/merge first, etc. -->

## Testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how
      your change affects other areas of the code, etc. -->
<!--- Reviewers will use this section to test the submission! -->
- [x] I tested on a generic Tripal Site
- [ ] I tested on a KnowPulse Clone
- [ ] This PR includes automated testing

You can test by modifying the existing sample VCF files in sample_files/, or you can play around with the regex `\b\.*\b` in an online regex tester such as phpliveregex.com ([Here's my test](https://www.phpliveregex.com/p/rwa))
