### PR TITLE
Fixes the regex that checks postgresql version to not assume 9.x

### DIFF
--- a/api/genotypes_loader.api.inc
+++ b/api/genotypes_loader.api.inc
@@ -13,7 +13,7 @@
 function genotypes_loader_recheck_postgresql_version() {
   $version_string = db_query('SELECT version()')->fetchField();
   $version = '9.2';
-  if (preg_match('/PostgreSQL (9\.\d+)\.\d+/', $version_string, $matches)) {
+  if (preg_match('/PostgreSQL (\d+\.\d+)\.\d+/', $version_string, $matches)) {
     $version = $matches[1];
   }
   variable_set('pgsql_version', $version);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- No need to include the issue number in the title :-) -->

## Metadata
<!--- If it fixes an open issue, please add the issue link below. -->
 - Issue #27 

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I feel this PR is ready to be merged.
- [ ] This PR is dependent upon [PR #/ nothing]

Documentation:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
This change was required because PostgreSQL 10.x has been released and this module assumed version 9.x when checking the user's current version. This change also takes into account future releases beyond 10.x by making the regex generic enough.

## Dependencies
<!-- If this code is dependent upon another module and/or PR, 
       state that here. -->
<!-- Include information about other modules/PRs needed for testing,
        which to enable/merge first, etc. -->

## Testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how
      your change affects other areas of the code, etc. -->
<!--- Reviewers will use this section to test the submission! -->
- [x] I tested on a generic Tripal Site
- [ ] I tested on a KnowPulse Clone
- [ ] This PR includes automated testing

As with PR #31, you can use a site like phpliveregex.com to test the new regex, or if you have PostgreSQL v10.x installed, try enabling the module and look for a green Drupal message at the top stating "Your postgresql version is: x.x" and ensure it is, in fact, the correct version. 
