### PR TITLE
add terms necessary for module

### DIFF
--- a/genotypes_loader.install
+++ b/genotypes_loader.install
@@ -32,6 +32,39 @@ function genotypes_loader_enable() {
       array( ':curr' => $pg_version )
     );
   }
+  
+  
+  // Add required terms for loader.
+
+  if (!chado_get_cvterm(['cv_id' => ['name' => 'stock_relationship'], 'name' => 'is_extracted_from'])) {
+
+    chado_insert_cvterm([
+      'id' => 'local:is_extracted_from',
+      'name' => 'is_extracted_from',
+      'cv_name' => 'stock_relationship',
+      'definition' => 'Describes a relationship between stocks.  Local term from the genotypes_loader module.'
+    ]);
+  }
+  
+  if (!chado_get_cvterm(['cv_id' => ['name' => 'stock_relationship'], 'name' => 'is_marker_of'])) {
+
+    chado_insert_cvterm([
+      'id' => 'local:is_marker_of',
+      'name' => 'is_marker_of',
+      'cv_name' => 'stock_relationship',
+      'definition' => 'Local term from the genotypes_loader module.'
+    ]);
+  }
+
+  if (!chado_get_cvterm(['cv_id' => ['name' => 'feature_property'], 'name' => 'marker_type'])) {
+    chado_insert_cvterm([
+      'id' => 'local:marker_type',
+      'name' => 'marker_type',
+      'cv_name' => 'feature_property',
+      'definition' => 'Local term from the genotypes_loader module.'
+    ]);
+  }
+  
 }
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- No need to include the issue number in the title :-) -->

## Metadata
<!--- If it fixes an open issue, please add the issue link below. -->
 - Issue #34

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I feel this PR is ready to be merged.
- [x] This PR is dependent upon [PR #/ nothing]

Documentation:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

I think for the module rating requirements, all terms used by this module should be inserted on install.  I think its a big grayer because you allow for custom terms, but, I still think inserting the default terms and notifying the user that they can change them is the right move.