### PR TITLE
Prioritize VCF "ID" field for variant and marker names.

### DIFF
--- a/includes/genotypes_loader.vcf.inc
+++ b/includes/genotypes_loader.vcf.inc
@@ -113,8 +113,13 @@ function genotypes_loader_load_VCF($input_file = NULL, $options, $terms) {
     ));
     if (!$chromosome_id) { return drush_set_error(dt('ERROR: Could not find a chromosome ID for @backbone', array('@backbone' => $backbone_name))); }
 
-    // @TODO: This works for KP but do we want to make it generic?
-    $variant_name = $marker['#CHROM'] . 'p' . $marker['POS'];
+    // If there is a value for ID, use it as the variant name.
+    $variant_name = $marker['ID'];
+    if ($variant_name == '.') {
+      // @TODO: This works for KP but do we want to make it generic?
+      $variant_name = $marker['#CHROM'] . 'p' . $marker['POS'];
+    }
+
     $marker_name = $variant_name . ' ' . ucwords(str_replace('_',' ',$options['marker_type']));
 
     // Now create a variant and marker in Chado, and link it to a chromosome.

--- a/sample_files/cats.vcf
+++ b/sample_files/cats.vcf
@@ -1,4 +1,4 @@
 ##fileformat=VCFv4.0
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	Ross	Prado	Ash	Piero	Tai	Beverly	Argent	Trenus	Zapelli	Amato	Fireball	StabbyStab
 1A	11111	.	A	G,C	29	PASS	.	GT:DP	0/0:10	0/0:9	0/0:8	0/1:9	./.	1/1:5	0/1:11	0/0:3	1/1:6	0/0:4	2/2:5	2/2:8
-1A	22222	.	T	C,A	36	PASS	.	GT:DP	1/1:5	0/0:7	0/0:15	./.	0/0:8	0/1:5	0/0:1	0/1:13	0/0:6	1/1:4	2/2:8	0/2:6
+1A	22222	Catscription Factor 1	T	C,A	36	PASS	.	GT:DP	1/1:5	0/0:7	0/0:15	./.	0/0:8	0/1:5	0/0:1	0/1:13	0/0:6	1/1:4	2/2:8	0/2:6

--- a/tests/dataIntegrityTest.php
+++ b/tests/dataIntegrityTest.php
@@ -115,6 +115,19 @@ class dataIntegrityTest extends TripalTestCase {
     $this->assertEquals(22, $num_calls,
       'There was not the expected number of calls in the genotype_call table for this project: '.$project->project_id);
 
+
+    // If the VCF "ID" field is provided use it for variant/marker names.
+    // See Issue #38
+    // Check for variant '1Ap11111' and 'Catscription Factor 1' exist but '1Ap22222' doesn't.
+    $result = chado_select_record('feature',['feature_id'],['name'=>'1Ap11111', 'organism_id' => $organism->organism_id]);
+    $this->assertNotEmpty($result, 'Unable to find 1Ap11111 variant.');
+
+    $result = chado_select_record('feature',['feature_id'],['name'=>'Catscription Factor 1', 'organism_id' => $organism->organism_id]);
+    $this->assertNotEmpty($result, 'Unable to find "Catscription Factor 1" variant.');
+
+    $result = chado_select_record('feature',['feature_id'],['name'=>'1Ap22222', 'organism_id' => $organism->organism_id]);
+    $this->assertEmpty($result, 'Should not find 1Ap22222 variant.');
+
     // Clean up ALL THE THINGS!
     // --------------------------------
     foreach ($delete as $table => $ids) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- No need to include the issue number in the title :-) -->

## Metadata
<!--- If it fixes an open issue, please add the issue link below. -->
 - Issue #38 

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I feel this PR is ready to be merged.
- [ ] This PR is dependent upon [PR #/ nothing]

Documentation:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

It would be nice to mention somewhere how the module sets the variant/marker names. I will add this to my growing list of doc improvements...

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
For VCF files, this sets the default variant name (and by extension, the marker name) to the value in the ID field. If the ID field is blank (ie. '.'), then it uses my previous naming scheme, which is to concatenate the CHROM and POS fields separated by a "p". Previously, only this naming scheme was used.

## Testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how
      your change affects other areas of the code, etc. -->
<!--- Reviewers will use this section to test the submission! -->
See PR #18 for detailed instructions on setting up this module in a cloud9 environment.


- [x] I tested on a generic Tripal Site
- [ ] I tested on a KnowPulse Clone
- [x] This PR includes automated testing
