### PR TITLE
Allow PostgreSQL version 10.x and up

### DIFF
--- a/api/genotypes_loader.api.inc
+++ b/api/genotypes_loader.api.inc
@@ -13,9 +13,10 @@
 function genotypes_loader_recheck_postgresql_version() {
   $version_string = db_query('SELECT version()')->fetchField();
   $version = '9.2';
-  if (preg_match('/PostgreSQL (\d+\.\d+)\.\d+/', $version_string, $matches)) {
+  if (preg_match('/PostgreSQL (\d+\.\d+)/', $version_string, $matches)) {
     $version = $matches[1];
   }
+
   variable_set('pgsql_version', $version);
 
   return $version;
@@ -25,7 +26,7 @@ function genotypes_loader_recheck_postgresql_version() {
   * Retrieve the postgreSQL version.
   */
 function genotypes_loader_get_postgresql_version() {
-  return variable_get('pgsql_version', '9.2');
+  return variable_get('pgsql_version', genotypes_loader_recheck_postgresql_version());
 }
 
 /**

--- a/genotypes_loader.install
+++ b/genotypes_loader.install
@@ -12,7 +12,7 @@ function genotypes_loader_enable() {
   
   // If not using PostgreSQL 9.3+, give an error
   if (is_numeric($pg_version)) {
-    if ($pg_version < 9.3) {
+    if (version_compare($pg_version, '9.3', '<')) {
       drupal_set_message(t('This module requires PostgreSQL 9.3 or higher.'), 'error');
       
       tripal_report_error(


### PR DESCRIPTION
Previously we attempted to address this in PR #32 but the regex still failed for 10.x versions of PostgreSQL.

## Metadata
<!--- If it fixes an open issue, please add the issue link below. -->
 - Issue #27 

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I feel this PR is ready to be merged.
- [ ] This PR is dependent upon [PR #/ nothing]

Documentation:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

The previous change to this regex still anticipated a sub-sub-version (eg. 9.4.3) which isn't always the case. So it has now been altered to only capture the version and subversion (i.e. 9.4) since only 9.3 or higher is required by the module. Additionally, I switched to using PHP's built-in version_compare function.

## Testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how
      your change affects other areas of the code, etc. -->
<!--- Reviewers will use this section to test the submission! -->
- [x] I tested on a generic Tripal Site
- [ ] I tested on a KnowPulse Clone
- [ ] This PR includes automated testing

You can see @laceysanderson demonstrating the regex here: https://github.com/UofS-Pulse-Binfo/genotypes_loader/issues/27#issuecomment-480881867

I tested using a dummy variable for the following and got the expected outcomes: 9.2, 9.4, 10.5

If you have PostgreSQL v10.x installed, try enabling the module and look for a green Drupal message at the top stating "Your postgresql version is: x.x" and ensure it is, in fact, the correct version.
